### PR TITLE
Use bats-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,35 @@
-FROM lucor/bats:latest@sha256:88cf23ca5cd5451d9a88967fd17d4b2fb35b37c5662d2ed4b59fc4039aad2f0d
+FROM bats/bats:latest@sha256:e7a5e065814b784c51219ee460d9901d9d44cd642dfc2dc3a3006e52334e8705
 
-ENV LIBS_BATS_MOCK_VERSION "1.1.0"
+ENV LIBS_BATS_MOCK_VERSION="1.1.0" \
+    LIBS_BATS_SUPPORT_VERSION="0.3.0"
 
+RUN apk --no-cache add ncurses curl
+
+# Install bats-support
+RUN mkdir -p /usr/local/lib/bats/bats-support \
+    && curl -sSL https://github.com/ztombol/bats-support/archive/v0.3.0.tar.gz -o /tmp/bats-support.tgz \
+    && tar -zxf /tmp/bats-support.tgz -C /usr/local/lib/bats/bats-support --strip 1 \
+    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-support/load.bash" >> /usr/local/lib/bats/load.bash \
+    && rm -rf /tmp/bats-support.tgz
+
+# Install bats-assert
+RUN mkdir -p /usr/local/lib/bats/bats-assert \
+    && curl -sSL https://github.com/ztombol/bats-assert/archive/v0.3.0.tar.gz -o /tmp/bats-assert.tgz \
+    && tar -zxf /tmp/bats-assert.tgz -C /usr/local/lib/bats/bats-assert --strip 1 \
+    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-assert/load.bash" >> /usr/local/lib/bats/load.bash \
+    && rm -rf /tmp/bats-assert.tgz
+
+# Install lox's fork of bats-mock
 RUN mkdir -p /usr/local/lib/bats/bats-mock \
     && curl -sSL https://github.com/lox/bats-mock/archive/master.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz
 
-RUN apk --no-cache add ncurses
-
 # Expose BATS_PATH so people can easily use load.bash
 ENV BATS_PATH=/usr/local/lib/bats
 
 WORKDIR /plugin
+
+ENTRYPOINT []
 CMD ["bats", "tests/"]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A base [Docker](https://www.docker.com/) image for testing [Buildkite plugins](https://buildkite.com/docs/agent/v3/plugins) with BATS. It includes:
 
-* [bats](https://github.com/sstephenson/bats)
+* [bats-core](https://github.com/bats-core/bats-core)
 * [bats-assert](https://github.com/ztombol/bats-assert)
-* [bats-mock](https://github.com/lox/bats-mock)
+* [@lox](https://github.com/lox)'s fork of [bats-mock](https://github.com/lox/bats-mock)
 
 Your plugin’s code is expected to be mounted to `/plugin`, and by default the image will run the command `bats tests/`.
 
@@ -44,9 +44,9 @@ load "$BATS_PATH/load.bash"
   export BUILDKITE_PLUGIN_GIT_LOGGER_COMMIT="abc123"
 
   stub git "log abc123 : echo git log output"
-  
+
   run $PWD/hooks/command
-  
+
   assert_output --partial "git log output"
   assert_success
   unstub git


### PR DESCRIPTION
For a long time the original [bats](https://github.com/sstephenson/bats) project has been dormant. There is now a big push to create a canonical modern version at https://github.com/bats-core/bats-core, which will be great 🎉

This moves our plugin tester to use the new bats-core, which should mean new goodness soon!