### PR TITLE
Install bats-mock by version so we can bump it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /usr/local/lib/bats/bats-assert \
 
 # Install lox's fork of bats-mock
 RUN mkdir -p /usr/local/lib/bats/bats-mock \
-    && curl -sSL https://github.com/lox/bats-mock/archive/master.tar.gz -o /tmp/bats-mock.tgz \
+    && curl -sSL https://github.com/lox/bats-mock/archive/v1.3.0.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz


### PR DESCRIPTION
This installs bats-mock by version, so we can bump it to get a patch that I'd like to make use of. 