### PR TITLE
Add jq to the container, so we don't have to stub it out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM bats/bats:latest@sha256:97d91ee0aa9771e696cdf44c2b1672af484fd846eaf52ba2db6
 ENV LIBS_BATS_MOCK_VERSION="1.1.0" \
     LIBS_BATS_SUPPORT_VERSION="0.3.0"
 
-RUN apk --no-cache add ncurses curl
+RUN apk --no-cache add ncurses curl jq
 
 # Install bats-support
 RUN mkdir -p /usr/local/lib/bats/bats-support \


### PR DESCRIPTION
It seems a pattern for Buildkite Plugins is to mock out `jq`. This is IMO brittle as we end up having to update tests for every change we make to jq and are not doing integration tests with jq, resulting in bugs in our plugins.

I think it would be better to actually run jq instead of stubbing it out. This would result in more reliable tests (not easily broken by small changes) and less bugs.