### PR TITLE
Update to bats-core v1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,24 @@
-FROM bats/bats:latest@sha256:97d91ee0aa9771e696cdf44c2b1672af484fd846eaf52ba2db6061f5c78a89d5
-
-ENV LIBS_BATS_MOCK_VERSION="1.3.0" \
-    LIBS_BATS_SUPPORT_VERSION="0.3.0"
+FROM bats/bats:latest@sha256:30d870103cd5aee7e76649685df6921cc902972a62860859c6ed3c19769dff41
 
 RUN apk --no-cache add ncurses curl jq
 
 # Install bats-support
 RUN mkdir -p /usr/local/lib/bats/bats-support \
-    && curl -sSL https://github.com/ztombol/bats-support/archive/v0.3.0.tar.gz -o /tmp/bats-support.tgz \
+    && curl -sSL https://github.com/bats-core/bats-support/archive/v0.3.0.tar.gz -o /tmp/bats-support.tgz \
     && tar -zxf /tmp/bats-support.tgz -C /usr/local/lib/bats/bats-support --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-support/load.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-support.tgz
 
 # Install bats-assert
 RUN mkdir -p /usr/local/lib/bats/bats-assert \
-    && curl -sSL https://github.com/ztombol/bats-assert/archive/v0.3.0.tar.gz -o /tmp/bats-assert.tgz \
+    && curl -sSL https://github.com/bats-core/bats-assert/archive/v0.3.0.tar.gz -o /tmp/bats-assert.tgz \
     && tar -zxf /tmp/bats-assert.tgz -C /usr/local/lib/bats/bats-assert --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-assert/load.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-assert.tgz
 
 # Install lox's fork of bats-mock
 RUN mkdir -p /usr/local/lib/bats/bats-mock \
-    && curl -sSL https://github.com/lox/bats-mock/archive/v${LIBS_BATS_MOCK_VERSION}.tar.gz -o /tmp/bats-mock.tgz \
+    && curl -sSL https://github.com/lox/bats-mock/archive/v1.3.0.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz
@@ -31,8 +28,8 @@ RUN mkdir -p /usr/local/lib/bats/bats-mock \
 # `#!/bin/bash` as their shebang
 RUN if [[ -e /bin/bash ]]; then echo "/bin/bash already exists"; exit 1; else ln -s /usr/local/bin/bash /bin/bash; fi
 
-# Expose BATS_PATH so people can easily use load.bash
-ENV BATS_PATH=/usr/local/lib/bats
+# Expose BATS_LIB_PATH so people can easily use load.bash
+ENV BATS_PLUGIN_PATH=/usr/local/lib/bats
 
 WORKDIR /plugin
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Buildkite Plugin Tester [![Build status](https://badge.buildkite.com/f6ce96d897af406221809efe925c0808cc49cdcf5b91771ce0.svg?branch=master)](https://buildkite.com/buildkite/plugin-tester)
+# Buildkite Plugin Tester [![Build status](https://badge.buildkite.com/f6ce96d897af406221809efe925c0808cc49cdcf5b91771ce0.svg?branch=main)](https://buildkite.com/buildkite/plugin-tester)
 
 A base [Docker](https://www.docker.com/) image for testing [Buildkite plugins](https://buildkite.com/docs/agent/v3/plugins) with BATS. It includes:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ And you'd create the following test in `tests/command.bats`:
 ```bash
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export GIT_STUB_DEBUG=/dev/tty

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 A base [Docker](https://www.docker.com/) image for testing [Buildkite plugins](https://buildkite.com/docs/agent/v3/plugins) with BATS. It includes:
 
 * [bats-core](https://github.com/bats-core/bats-core)
-* [bats-assert](https://github.com/ztombol/bats-assert)
-* [@lox](https://github.com/lox)'s fork of [bats-mock](https://github.com/lox/bats-mock)
+* [bats-support](https://github.com/bats-core/bats-support)
+* [bats-assert](https://github.com/bats-core/bats-assert)
+* [bats-mock](https://github.com/lox/bats-mock)
 
 Your plugin’s code is expected to be mounted to `/plugin`, and by default the image will run the command `bats tests/`.
 

--- a/tests/test-plugin/tests/test.bats
+++ b/tests/test-plugin/tests/test.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # export FOO_STUB_DEBUG=/dev/tty
 


### PR DESCRIPTION
Bringing #31 back to life, this updates bats-core to [v1.7.0](https://github.com/bats-core/bats-core/releases/tag/v1.7.0)

It introduces a necessary breaking change, renaming `BATS_PATH` to `BATS_PLUGIN_PATH`, because `BATS_PATH` is now used internally by bats.

To update tests:

```diff
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"

@test "prints some output" {
  run $PWD/hooks/command
  assert_output --partial "some output"
  assert_success
}
```