### PR TITLE
Update `bats-mock` to 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/local/lib/bats/bats-assert \
 
 # Install lox's fork of bats-mock
 RUN mkdir -p /usr/local/lib/bats/bats-mock \
-    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v1.4.0.tar.gz -o /tmp/bats-mock.tgz \
+    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.0.0.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/local/lib/bats/bats-assert \
 
 # Install lox's fork of bats-mock
 RUN mkdir -p /usr/local/lib/bats/bats-mock \
-    && curl -sSL https://github.com/lox/bats-mock/archive/v1.3.0.tar.gz -o /tmp/bats-mock.tgz \
+    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v1.4.0.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To test this, you'd add the following `docker-compose.yml` file:
 version: '3.4'
 services:
   tests:
-    image: buildkite/plugin-tester:v2.0.0
+    image: buildkite/plugin-tester:v3.0.0
     volumes:
       - ".:/plugin"
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A base [Docker](https://www.docker.com/) image for testing [Buildkite plugins](h
 * [bats-core](https://github.com/bats-core/bats-core)
 * [bats-support](https://github.com/bats-core/bats-support)
 * [bats-assert](https://github.com/bats-core/bats-assert)
-* [bats-mock](https://github.com/lox/bats-mock)
+* [bats-mock](https://github.com/buildkite-plugins/bats-mock)
 * [bats-file](https://github.com/bats-core/bats-file)
 
 Your plugin’s code is expected to be mounted to `/plugin`, and by default the image will run the command `bats tests/`.


### PR DESCRIPTION
Updates the `bats-mock` library to the latest version to solve issues with multi-line command stubbing. As it can't guarantee backwards-compatibility, it makes sense this one doesn't either so I bumped the major version here as well.

Note: pipeline is failing because the version has not been released yet