### PR TITLE
Update backs-mock to correct bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/local/lib/bats/bats-assert \
 
 # Install lox's fork of bats-mock
 RUN mkdir -p /usr/local/lib/bats/bats-mock \
-    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.0.0.tar.gz -o /tmp/bats-mock.tgz \
+    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.0.1.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz


### PR DESCRIPTION
There was a bug in the recently released `bats-mock` that meant that stubs including an `exit X` did not correctly propagate the exit code