### PR TITLE
Xmas 2022 updates

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":docker: :hammer:"
     plugins:
-      docker-compose#v4.5.0:
+      docker-compose#v4.9.0:
         run: tests
 
   - wait
@@ -9,7 +9,7 @@ steps:
   - label: ":docker: :rocket: Latest"
     plugins:
       docker-login#v2.1.0: ~
-      docker-compose#v4.5.0:
+      docker-compose#v4.9.0:
         push: latest
     if: |
       build.branch == 'main'
@@ -17,7 +17,7 @@ steps:
   - label: ":docker: :rocket: Tag"
     plugins:
       docker-login#v2.1.0: ~
-      docker-compose#v4.5.0:
+      docker-compose#v4.9.0:
         push: tag
     if: |
       build.tag != null

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 steps:
   - label: ":docker: :hammer:"
     plugins:
-      docker-compose#v4.5.0:
+      docker-compose#v4.9.0:
         run: tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bats/bats:latest@sha256:c707c5b7f9afd49da3e8a94248b03832e8b427f1b8f1ae9ec3cfdc5596d9c9f4
+FROM bats/bats:latest@sha256:c3db40540a4942497a8c7ca1ea9fbbf2faf269381f2761380c29154edf5526c4
 
 RUN apk --no-cache add ncurses curl jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/local/lib/bats/bats-assert \
 
 # Install lox's fork of bats-mock
 RUN mkdir -p /usr/local/lib/bats/bats-mock \
-    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.0.1.tar.gz -o /tmp/bats-mock.tgz \
+    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.1.0.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM bats/bats:1.8.2-no-faccessat2@sha256:ed084f4b241c7e43422ff0a1d624a3a9609ef804ac8953449d2da63d6b8246e0
 
 RUN apk --no-cache add ncurses curl jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# syntax=docker/dockerfile:1
-FROM bats/bats:1.8.2-no-faccessat2@sha256:ed084f4b241c7e43422ff0a1d624a3a9609ef804ac8953449d2da63d6b8246e0
+FROM bats/bats:1.8.2-no-faccessat2@sha256:ab8b147d6fd604a25872580db473a61d446370af00addfe0a0d8b4394eae0f6b
 
 RUN apk --no-cache add ncurses curl jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bats/bats:latest@sha256:c3db40540a4942497a8c7ca1ea9fbbf2faf269381f2761380c29154edf5526c4
+FROM bats/bats:latest-no-faccessat2@sha256:ab8b147d6fd604a25872580db473a61d446370af00addfe0a0d8b4394eae0f6b
 
 RUN apk --no-cache add ncurses curl jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bats/bats:latest-no-faccessat2@sha256:ab8b147d6fd604a25872580db473a61d446370af00addfe0a0d8b4394eae0f6b
+FROM bats/bats:1.8.2-no-faccessat2@sha256:ed084f4b241c7e43422ff0a1d624a3a9609ef804ac8953449d2da63d6b8246e0
 
 RUN apk --no-cache add ncurses curl jq
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /usr/local/lib/bats/bats-support \
 
 # Install bats-assert
 RUN mkdir -p /usr/local/lib/bats/bats-assert \
-    && curl -sSL https://github.com/bats-core/bats-assert/archive/v0.3.0.tar.gz -o /tmp/bats-assert.tgz \
+    && curl -sSL https://github.com/bats-core/bats-assert/archive/v2.1.0.tar.gz -o /tmp/bats-assert.tgz \
     && tar -zxf /tmp/bats-assert.tgz -C /usr/local/lib/bats/bats-assert --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-assert/load.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-assert.tgz

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ steps:
 To test this, you'd add the following `docker-compose.yml` file:
 
 ```yml
-version: '3.4'
+version: '3.8'
 services:
   tests:
     image: buildkite/plugin-tester:v3.0.1

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ steps:
 To test this, you'd add the following `docker-compose.yml` file:
 
 ```yml
-version: '3.8'
+version: '3.7'
 services:
   tests:
     image: buildkite/plugin-tester:v3.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.8'
 services:
   tests:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.7'
 services:
   tests:
     build: .

--- a/tests/test-plugin/tests/test-failure.bats
+++ b/tests/test-plugin/tests/test-failure.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+  load "$BATS_PLUGIN_PATH/load.bash"
+
+  # Uncomment to enable stub debugging
+  # export BAR_STUB_DEBUG=/dev/tty
+}
+
+@test "bats intentional failure - expects Not AOK" {
+  run bash -c "echo 'Not AOK!'; exit 1"
+  assert_failure
+}
+
+@test "bats-mock should throw error" {
+  stub bar "foo : exit 1"
+  run bar foo
+  assert_failure
+  unstub bar
+}
+
+@test "bats intentional failure - alerts error" {
+  run echo "error"
+
+  refute_line "success"
+  assert_line "error"
+
+  run exit 1
+  assert_failure
+}

--- a/tests/test-plugin/tests/test-success.bats
+++ b/tests/test-plugin/tests/test-success.bats
@@ -9,11 +9,6 @@ load "$BATS_PLUGIN_PATH/load.bash"
   assert_success
 }
 
-@test "bats intentional failure - expects Not AOK" {
-  run bash -c "echo 'Not AOK!'; exit 1"
-  assert_failure
-}
-
 @test "bats-mock works" {
   stub foo "bar : echo baz"
   run foo bar

--- a/tests/test-plugin/tests/test.bats
+++ b/tests/test-plugin/tests/test.bats
@@ -4,42 +4,19 @@ load "$BATS_PLUGIN_PATH/load.bash"
 
 # export FOO_STUB_DEBUG=/dev/tty
 
-@test "bats works AOK" {
-  run bash -c "echo 'AOK'"
+@test "bats-core/bats works AOK" {
+  run echo 'AOK'
   assert_success
 }
 
-@test "bats-mock works" {
-  stub foo \
-    "bar : echo baz"
+@test "Intentional Failure - Not AOK" {
+  run bash -c "echo 'Not AOK!'; exit 1"
+  assert_failure
+}
+
+@test "buildkite-plugins/bats-mock works" {
+  stub foo "bar : echo baz"
   run foo bar
   assert_success
   unstub foo
-}
-
-# # @test 'assert_success() status only' {
-# #   run bash -c "echo 'Error!'; exit 1"
-# #   assert_success
-# # }
-
-# # @test 'assert_failure() status only' {
-# #   run echo 'Success!'
-# #   assert_failure
-# # }
-
-# @test 'assert success' {
-#   run bash -c "echo 'this'"
-#   assert_success
-# }
-
-@test "echoing" {
-  run echo "AOK"
-  assert_success
-}
-
-@test "stubbing" {
-  stub greet "sayhi: echo hello"
-  run greet sayhi
-  assert_success
-  unstub greet
 }

--- a/tests/test-plugin/tests/test.bats
+++ b/tests/test-plugin/tests/test.bats
@@ -9,7 +9,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
   assert_success
 }
 
-@test "bats intentional failure - Not AOK" {
+@test "bats intentional failure - expects Not AOK" {
   run bash -c "echo 'Not AOK!'; exit 1"
   assert_failure
 }

--- a/tests/test-plugin/tests/test.bats
+++ b/tests/test-plugin/tests/test.bats
@@ -5,13 +5,41 @@ load "$BATS_PLUGIN_PATH/load.bash"
 # export FOO_STUB_DEBUG=/dev/tty
 
 @test "bats works AOK" {
-  echo "AOK"
+  run bash -c "echo 'AOK'"
   assert_success
 }
 
 @test "bats-mock works" {
-  stub foo "bar : echo baz"
-  foo bar
+  stub foo \
+    "bar : echo baz"
+  run foo bar
   assert_success
   unstub foo
+}
+
+# # @test 'assert_success() status only' {
+# #   run bash -c "echo 'Error!'; exit 1"
+# #   assert_success
+# # }
+
+# # @test 'assert_failure() status only' {
+# #   run echo 'Success!'
+# #   assert_failure
+# # }
+
+# @test 'assert success' {
+#   run bash -c "echo 'this'"
+#   assert_success
+# }
+
+@test "echoing" {
+  run echo "AOK"
+  assert_success
+}
+
+@test "stubbing" {
+  stub greet "sayhi: echo hello"
+  run greet sayhi
+  assert_success
+  unstub greet
 }

--- a/tests/test-plugin/tests/test.bats
+++ b/tests/test-plugin/tests/test.bats
@@ -4,17 +4,17 @@ load "$BATS_PLUGIN_PATH/load.bash"
 
 # export FOO_STUB_DEBUG=/dev/tty
 
-@test "bats-core/bats works AOK" {
+@test "bats works AOK" {
   run echo 'AOK'
   assert_success
 }
 
-@test "Intentional Failure - Not AOK" {
+@test "bats intentional failure - Not AOK" {
   run bash -c "echo 'Not AOK!'; exit 1"
   assert_failure
 }
 
-@test "buildkite-plugins/bats-mock works" {
+@test "bats-mock works" {
   stub foo "bar : echo baz"
   run foo bar
   assert_success


### PR DESCRIPTION
- Upgrading `bats-core/bats-assert` from `v0.3.0` to `v2.1.0`
- Upgrading `bats-core/bats-core (bats/bats)` from `v1.7.0` to `v1.8.2 (no-faccessat2)`
- Upgrading `buildkite-plugins/docker-compose` from `v4.5.0` to `v4.9.0`
- Upgrading `buildkite-plugins/bats-mock` from `v2.0.1` to `v2.1.0`
- Upgrading `docker-compose spec` from `v2.0` to `v3.7`
- Upgrading the `test.bats` and splitting the tests into:
  - `test-success.bats`
  - `test-failure.bats`


Resolves https://github.com/buildkite-plugins/buildkite-plugin-tester/issues/56