### PR TITLE
bats image update consequences

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,33 +2,12 @@ FROM bats/bats:1.9.0-no-faccessat2@sha256:ebe8ebd3138b293af3b3d648ad703951cf22db
 
 RUN apk --no-cache add ncurses curl jq
 
-# Install bats-support
-RUN mkdir -p /usr/local/lib/bats/bats-support \
-    && curl -sSL https://github.com/bats-core/bats-support/archive/v0.3.0.tar.gz -o /tmp/bats-support.tgz \
-    && tar -zxf /tmp/bats-support.tgz -C /usr/local/lib/bats/bats-support --strip 1 \
-    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-support/load.bash" >> /usr/local/lib/bats/load.bash \
-    && rm -rf /tmp/bats-support.tgz
-
-# Install bats-assert
-RUN mkdir -p /usr/local/lib/bats/bats-assert \
-    && curl -sSL https://github.com/bats-core/bats-assert/archive/v2.1.0.tar.gz -o /tmp/bats-assert.tgz \
-    && tar -zxf /tmp/bats-assert.tgz -C /usr/local/lib/bats/bats-assert --strip 1 \
-    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-assert/load.bash" >> /usr/local/lib/bats/load.bash \
-    && rm -rf /tmp/bats-assert.tgz
-
-# Install lox's fork of bats-mock
+# Install our fork of bats-mock
 RUN mkdir -p /usr/local/lib/bats/bats-mock \
     && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.1.0.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
     && rm -rf /tmp/bats-mock.tgz
-
-# Install bats-file
- RUN mkdir -p /usr/local/lib/bats/bats-file \
-     && curl -sSL https://github.com/bats-core/bats-file/archive/v0.3.0.tar.gz -o /tmp/bats-file.tgz \
-     && tar -zxf /tmp/bats-file.tgz -C /usr/local/lib/bats/bats-file --strip 1 \
-     && printf 'source "%s"\n' "/usr/local/lib/bats/bats-file/load.bash" >> /usr/local/lib/bats/load.bash \
-     && rm -rf /tmp/bats-file.tgz
 
 # Make sure /bin/bash is available, as bats/bats only has it at
 # /usr/local/bin/bash and many plugin hooks (and shellscripts in general) use

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,26 @@ FROM bats/bats:1.9.0-no-faccessat2@sha256:ebe8ebd3138b293af3b3d648ad703951cf22db
 
 RUN apk --no-cache add ncurses curl jq
 
+# Expose BATS_LIB_PATH so people can easily use load.bash
+ENV BATS_PLUGIN_PATH=/usr/lib/bats
+
 # Install our fork of bats-mock
-RUN mkdir -p /usr/local/lib/bats/bats-mock \
+RUN mkdir -p "${BATS_PLUGIN_PATH}"/bats-mock \
     && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.1.0.tar.gz -o /tmp/bats-mock.tgz \
-    && tar -zxf /tmp/bats-mock.tgz -C /usr/local/lib/bats/bats-mock --strip 1 \
-    && printf 'source "%s"\n' "/usr/local/lib/bats/bats-mock/stub.bash" >> /usr/local/lib/bats/load.bash \
+    && tar -zxf /tmp/bats-mock.tgz -C "${BATS_PLUGIN_PATH}"/bats-mock --strip 1 \
     && rm -rf /tmp/bats-mock.tgz
+
+# Provide a convenient way to load all plugins at once
+RUN printf 'source "%s"\n' "${BATS_PLUGIN_PATH}/bats-assert/load.bash" >> "${BATS_PLUGIN_PATH}"/load.bash \
+    && printf 'source "%s"\n' "${BATS_PLUGIN_PATH}/bats-mock/stub.bash" >> "${BATS_PLUGIN_PATH}"/load.bash \
+    && printf 'source "%s"\n' "${BATS_PLUGIN_PATH}/bats-file/load.bash" >> "${BATS_PLUGIN_PATH}"/load.bash \
+    && printf 'source "%s"\n' "${BATS_PLUGIN_PATH}/bats-support/load.bash" >> "${BATS_PLUGIN_PATH}"/load.bash
 
 # Make sure /bin/bash is available, as bats/bats only has it at
 # /usr/local/bin/bash and many plugin hooks (and shellscripts in general) use
 # `#!/bin/bash` as their shebang
 RUN if [[ -e /bin/bash ]]; then echo "/bin/bash already exists"; exit 1; else ln -s /usr/local/bin/bash /bin/bash; fi
 
-# Expose BATS_LIB_PATH so people can easily use load.bash
-ENV BATS_PLUGIN_PATH=/usr/local/lib/bats
 
 WORKDIR /plugin
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":disableDependencyDashboard"
   ],
   "pinDigests": false
 }


### PR DESCRIPTION
The update to vats 1.9.0 simplifies the image we now create as it already includes all the core plugins inside of it.

I have tested the image against a few other plugins and the whole thing works... as long as they have not [hardcoded the path to the loading script](https://github.com/buildkite-plugins/docker-compose-buildkite-plugin/blob/36680afdefb3f4aba6b661685d9dfba4d61f5346/tests/build.bats#L3) (`load "${BATS_PLUGIN_PATH}/load.bash"
` should be used instead).

While I was at it, I deactivated the dependency dashboard.