### PR TITLE
Update bats-mock lib version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV BATS_PLUGIN_PATH=/usr/lib/bats
 
 # Install our fork of bats-mock
 RUN mkdir -p "${BATS_PLUGIN_PATH}"/bats-mock \
-    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.1.0.tar.gz -o /tmp/bats-mock.tgz \
+    && curl -sSL https://github.com/buildkite-plugins/bats-mock/archive/v2.1.1.tar.gz -o /tmp/bats-mock.tgz \
     && tar -zxf /tmp/bats-mock.tgz -C "${BATS_PLUGIN_PATH}"/bats-mock --strip 1 \
     && rm -rf /tmp/bats-mock.tgz
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To test this, you'd add the following `docker-compose.yml` file:
 version: '3.7'
 services:
   tests:
-    image: buildkite/plugin-tester:v4.0.0
+    image: buildkite/plugin-tester:v4.1.1
     volumes:
       - ".:/plugin"
 ```


### PR DESCRIPTION
We did a new release in bats-mock (https://github.com/buildkite-plugins/bats-mock/releases/tag/v2.1.1) so we need to update the tester