### PR TITLE
Build image for pushing

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -10,6 +10,7 @@ steps:
     plugins:
       docker-login#v3.0.0: ~
       docker-compose#v5.2.0:
+        build: latest
         push: latest
     if: |
       build.branch == 'main'
@@ -18,6 +19,7 @@ steps:
     plugins:
       docker-login#v3.0.0: ~
       docker-compose#v5.2.0:
+        build: tag
         push: tag
     if: |
       build.tag != null


### PR DESCRIPTION
Since the upgrade to Compose v5+ released images (and `latest`) were not being pushed because they were not built automatically as they were before.